### PR TITLE
fix for _load_psf_blacklist, and some python 3 compatibility changes

### DIFF
--- a/ngmixer/bootfit.py
+++ b/ngmixer/bootfit.py
@@ -22,6 +22,8 @@ from ngmix.jacobian import Jacobian
 
 from pprint import pprint
 
+from six.moves import xrange
+
 def get_bootstrapper(obs, type='boot', **keys):
     from ngmix.bootstrap import Bootstrapper
     from ngmix.bootstrap import CompositeBootstrapper

--- a/ngmixer/files.py
+++ b/ngmixer/files.py
@@ -99,7 +99,6 @@ def get_meds_files(medsconf, tile_id, bands):
     fnames = []
     for band in bands:
         fname=desmeds.files.get_meds_file(medsconf, tile_id, band)
-        fname = os.path.join(dir, fname)
         fnames.append(fname)
 
     return fnames

--- a/ngmixer/imageio/medsio.py
+++ b/ngmixer/imageio/medsio.py
@@ -76,7 +76,7 @@ class MEDSImageIO(ImageIO):
         if self.conf['model_nbrs']:
             assert 'nbrs' in self.extra_data,"You must supply a nbrs file to model nbrs!"
 
-    def _load_psf_blacklist():
+    def _load_psf_blacklist(self):
         self.psf_blacklist = {}
 
     def _set_defaults(self):

--- a/ngmixer/imageio/medsio.py
+++ b/ngmixer/imageio/medsio.py
@@ -62,6 +62,7 @@ class MEDSImageIO(ImageIO):
         self.conf['max_cutouts'] = self.conf.get('max_cutouts',None)
 
         pconf=self.conf['imageio']['psfs']
+        #Load the psf blacklist - this just loads an empty dict for the base class
         self._load_psf_blacklist()
 
         # indexing of fofs
@@ -74,6 +75,9 @@ class MEDSImageIO(ImageIO):
         # make sure if we are doing nbrs we have the info we need
         if self.conf['model_nbrs']:
             assert 'nbrs' in self.extra_data,"You must supply a nbrs file to model nbrs!"
+
+    def _load_psf_blacklist():
+        self.psf_blacklist = {}
 
     def _set_defaults(self):
         self.conf['min_weight'] = self.conf.get('min_weight',-numpy.inf)

--- a/ngmixer/ngmixing.py
+++ b/ngmixer/ngmixing.py
@@ -16,6 +16,8 @@ from .defaults import NO_ATTEMPT,NO_CUTOUTS,BOX_SIZE_TOO_BIG,IMAGE_FLAGS,BAD_OBJ
 
 from .util import UtterFailure, seed_numpy
 
+import six
+from six.moves import xrange, cPickle
 
 class NGMixer(dict):
     def __init__(self,
@@ -554,7 +556,6 @@ class NGMixer(dict):
         See if checkpoint data was sent
         """
         import fitsio
-        import cPickle
 
         self.checkpoint_data = None
 

--- a/ngmixer/priors.py
+++ b/ngmixer/priors.py
@@ -4,6 +4,7 @@ import os
 import ngmix
 import fitsio
 import numpy
+from six import iteritems
 
 def set_priors(conf):
     """


### PR DESCRIPTION
The main point of this PR was to fix the fact that `MEDSImageIO` does not have a `_load_psf_blacklist` method, yet it is called in `__init__`. So I added a method which just sets a `self.psf_blacklist={}`. I happened to be testing this with python 3, and there were some compatibility issues that I also added fixes for.